### PR TITLE
Update js5 monitor to rev 223

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # js5-monitor
 monitors the osrs servers for the weekly resets. Uses a JS5 connection
+
+## Relevant Threads
+https://rune-server.org/threads/the-update-protocol.191916/
+https://rune-server.org/threads/osrs-js5-protocol.660204/
+https://github.com/Guthix/Jagex-Store-5
+
+This file in the runelite cache code updater repo by Abex on the RuneLite team is kept up to date. It should
+be referenced for changes to the protocol -
+https://github.com/abextm/runelite-cache-code-updater/blob/master/src/main/java/net/runelite/cache/codeupdater/client/JS5Client.java
+Git history of the above file - 
+https://github.com/abextm/runelite-cache-code-updater/commits/master/src/main/java/net/runelite/cache/codeupdater/client/JS5Client.java

--- a/database_handler.go
+++ b/database_handler.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"database/sql"
-	"fmt"
 	_ "github.com/mattn/go-sqlite3"
+	"log"
 	"strconv"
 	"time"
 )
@@ -55,7 +55,7 @@ func queryDBForLastServerReset(database *sql.DB) (bool, ServerResetInfo) {
 			LastServerUptime:  int64LastServerUptime,
 		}
 		numberOfEntries++
-		fmt.Println("Finding rows: ", numberOfEntries, serverResetInfo)
+		log.Println("Finding rows: ", numberOfEntries, serverResetInfo)
 	}
 
 	entryExistsInDB := numberOfEntries == 1

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.17
 require (
 	github.com/gorilla/mux v1.8.0
 	github.com/mattn/go-sqlite3 v1.14.11
+	github.com/pkg/errors v0.9.1
 )

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/mattn/go-sqlite3 v1.14.11 h1:gt+cp9c0XGqe9S/wAHTL3n/7MqY+siPWgWJgqdsFrzQ=
 github.com/mattn/go-sqlite3 v1.14.11/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/js5_monitor.go
+++ b/js5_monitor.go
@@ -54,7 +54,9 @@ func getLastReset(w http.ResponseWriter, r *http.Request) {
 func consoleLoop() {
 
 	js5, err := js5connection.New()
-	fmt.Println(err)
+	if err != nil {
+		fmt.Println(err.Error())
+	}
 	//fmt.Println(js5.Ping())
 
 	var loopCounter float64 = 0
@@ -74,13 +76,13 @@ func consoleLoop() {
 
 // MonitorJS5
 //  1. Start by initializing db and getting the first server reset. If it's the first time, just set time to now.
-//	2. Initialize JS5 Connection. If it fails to connect, keep trying. Server may be down.
-//		3. Ping the connection every 5 seconds in a new loop.
-//		4. If the connection breaks, break out of current loop
-//	5. Be sure to take the difference between the time for last reset and current reset.
-//	6. Write to DB
-//	7. Set LastServerResetInfo to current one.
-//	8. restart loop at step 2.
+//  2. Initialize JS5 Connection. If it fails to connect, keep trying. Server may be down.
+//  3. Ping the connection every 5 seconds in a new loop.
+//  4. If the connection breaks, break out of current loop
+//  5. Be sure to take the difference between the time for last reset and current reset.
+//  6. Write to DB
+//  7. Set LastServerResetInfo to current one.
+//  8. restart loop at step 2.
 func MonitorJS5() {
 
 	LastServerResetInfo = initServerResetInfo(db)
@@ -88,10 +90,9 @@ func MonitorJS5() {
 	for { // Infinite Loop
 		time.Sleep(js5connection.PingInterval)
 		js5, err := js5connection.New()
-		fmt.Println(&js5)
-
 		if err != nil {
 			// Start over by trying a new connection
+			log.Printf("Unable to create js5connection, retrying...: %s", err.Error())
 			continue
 		}
 
@@ -123,7 +124,7 @@ func initServerResetInfo(database *sql.DB) *ServerResetInfo {
 
 	var lastServerReset ServerResetInfo
 
-	fmt.Println("Looking for entry in database...")
+	log.Println("Looking for entry in database...")
 	entryExists, lastServerReset := queryDBForLastServerReset(database)
 
 	if !entryExists { // entry does not exist in db
@@ -132,7 +133,7 @@ func initServerResetInfo(database *sql.DB) *ServerResetInfo {
 			LastResetTimeUnix: time.Now().Unix(),
 			LastServerUptime:  0,
 		}
-		fmt.Println("Could not find entry in database")
+		log.Println("Could not find entry in database")
 		addNewServerResetInfo(lastServerReset, db)
 	}
 


### PR DESCRIPTION
Looks like a new revision of js5 was pushed that broke old versions (rev223). The fix is to write four 0 ints after writing the rev. Credit goes to Abex for [this commit](https://github.com/abextm/runelite-cache-code-updater/commit/0598156b3d3b92ad03d3377246802357d0eaad31#diff-ddfc458da83e4bf5b4237fa3dcd08371adf8bb033ad9f2abf1a6fb24db029834R104) that showed me what to do.